### PR TITLE
Enhance error handling and robustness across the codebase

### DIFF
--- a/src/IO/FileStream.cpp
+++ b/src/IO/FileStream.cpp
@@ -26,6 +26,13 @@ bool FileStream::IsOpen() const
 
 void* FileStream::ReadWrite(void* aBuffer, uint32_t aLength)
 {
+    if (!IsOpen())
+    {
+        auto fileName = m_path.stem();
+        spdlog::warn(L"[{}] read error: file is not open", fileName.c_str());
+        return nullptr;
+    }
+
     DWORD numberOfBytesRead;
     if (!ReadFile(m_file, aBuffer, aLength, &numberOfBytesRead, nullptr))
     {
@@ -41,6 +48,11 @@ void* FileStream::ReadWrite(void* aBuffer, uint32_t aLength)
 
 size_t FileStream::GetPointerPosition()
 {
+    if (!IsOpen())
+    {
+        return static_cast<size_t>(-1);
+    }
+
     LARGE_INTEGER filePointer{};
     if (!SetFilePointerEx(m_file, {0}, &filePointer, FILE_CURRENT))
     {
@@ -72,6 +84,13 @@ bool FileStream::Seek(size_t aDistance)
 
 bool FileStream::Seek(size_t aDistance, uint32_t aMoveMethod)
 {
+    if (!IsOpen())
+    {
+        auto fileName = m_path.stem();
+        spdlog::warn(L"[{}] seek error: file is not open", fileName.c_str());
+        return false;
+    }
+
     LARGE_INTEGER distance;
     distance.QuadPart = aDistance;
 
@@ -91,7 +110,12 @@ bool FileStream::Seek(size_t aDistance, uint32_t aMoveMethod)
 
 bool FileStream::Flush()
 {
-    return true;
+    if (!IsOpen())
+    {
+        return false;
+    }
+
+    return FlushFileBuffers(m_file) != 0;
 }
 
 std::filesystem::path FileStream::GetPath() const

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,4 +1,7 @@
-#include <iostream>
+#include <algorithm>
+#include <string>
+#include <vector>
+#include <mutex>
 
 #include <RED4ext/RED4ext.hpp>
 
@@ -9,8 +12,15 @@
 #include <InputLoader.hpp>
 
 namespace InputLoader {
+
+// Forward declaration so the default argument lives in a declaration (good
+// practice) instead of only in the definition. The signature is unchanged for
+// ABI/Source compatibility.
 pugi::xml_document LoadDocument(std::filesystem::path path,
-                                bool *status = nullptr) {
+                                bool *status = nullptr);
+
+pugi::xml_document LoadDocument(std::filesystem::path path,
+                                bool *status) {
 
   pugi::xml_document document;
   if (path.is_relative()) {
@@ -60,17 +70,46 @@ std::vector<std::string> valid_inputContexts = {
 pugi::xml_document inputContextsOriginal;
 pugi::xml_document inputUserMappingsOriginal;
 
+// Mutex protecting `document_paths` - the public Add() entrypoint may be
+// invoked concurrently by different RED4ext plugins from their own threads.
+static std::mutex document_paths_mutex;
 static std::vector<std::filesystem::path> document_paths;
 
 RED4EXT_C_EXPORT void Add(RED4ext::PluginHandle aHandle, const wchar_t * str) {
+  // Defensive: a misbehaving plugin may pass nullptr.
+  if (!str) {
+    spdlog::error("InputLoader::Add() called with a null path; ignoring.");
+    return;
+  }
+
   std::filesystem::path path(str);
   if (path.is_relative()) {
-    char dllFilePath[513] = {0};
-    GetModuleFileNameA(aHandle, dllFilePath, 512);
+    // Use the wide-character API to preserve Unicode paths and avoid the
+    // 512-byte truncation bug the previous ANSI buffer suffered from.
+    // We dynamically resize, mirroring the approach in Utils::GetRootDir().
+    std::wstring dllFilePath;
+    constexpr size_t pathChunk = MAX_PATH + 1;
+    do {
+      dllFilePath.resize(dllFilePath.size() + pathChunk, L'\0');
+      auto length = GetModuleFileNameW(aHandle, dllFilePath.data(),
+                                       static_cast<uint32_t>(dllFilePath.size()));
+      if (length > 0) {
+        dllFilePath.resize(length);
+      }
+    } while (GetLastError() == ERROR_INSUFFICIENT_BUFFER);
+
+    if (dllFilePath.empty()) {
+      spdlog::error("InputLoader::Add() - GetModuleFileNameW failed (errno={:#x}); ignoring path '{}'",
+                    GetLastError(), path.string());
+      return;
+    }
+
     std::filesystem::path dllPath(dllFilePath);
     path = dllPath.parent_path() / path;
   }
   spdlog::info(L"Will load document: {}", path.c_str());
+
+  std::lock_guard<std::mutex> guard(document_paths_mutex);
   document_paths.emplace_back(path);
 }
 
@@ -97,13 +136,25 @@ void MergeDocument(std::filesystem::path path) {
   // * radialDeadzone
   // * angularDeadzone
 
-  // pugi::xml_document modDocument =
-  // LoadDocument("r6/input/flight_control.xml");
-  pugi::xml_document modDocument = LoadDocument(path);
+  bool loadOk = true;
+  pugi::xml_document modDocument = LoadDocument(path, &loadOk);
   spdlog::info(L"Loading document: {}", path.c_str());
 
+  if (!loadOk) {
+    // LoadDocument already logged the parse error details; just bail out so
+    // we don't silently produce a partial merge.
+    spdlog::error(L"Skipping merge for '{}' due to parse/load errors", path.c_str());
+    return;
+  }
+
+  pugi::xml_node modBindings = modDocument.child("bindings");
+  if (!modBindings) {
+    spdlog::warn(L"Document '{}' has no <bindings> root; nothing to merge", path.c_str());
+    return;
+  }
+
   // process bindings
-  for (pugi::xml_node modNode : modDocument.child("bindings").children()) {
+  for (pugi::xml_node modNode : modBindings.children()) {
     spdlog::info("* Processing mod input block: {}", modNode.name());
     pugi::xml_node existing;
     pugi::xml_document *document;
@@ -123,17 +174,26 @@ void MergeDocument(std::filesystem::path path) {
       spdlog::warn("* <bindings> child '{}' not valid", modNode.name());
       continue;
     }
+
+    pugi::xml_node targetBindings = document->child("bindings");
+    if (!targetBindings) {
+      // Original document is malformed (no <bindings> root). Recreate it so
+      // we don't lose the mod's data, and warn loudly.
+      spdlog::warn("Target document had no <bindings> root; creating one.");
+      targetBindings = document->append_child("bindings");
+    }
+
     if (existing) {
       if (modNode.attribute("append").as_bool()) {
         for (pugi::xml_node modNodeChild : modNode.children()) {
           existing.append_copy(modNodeChild);
         }
       } else {
-        document->child("bindings").remove_child(existing);
-        document->child("bindings").append_copy(modNode);
+        targetBindings.remove_child(existing);
+        targetBindings.append_copy(modNode);
       }
     } else {
-      document->child("bindings").append_copy(modNode);
+      targetBindings.append_copy(modNode);
     }
   }
 }
@@ -141,17 +201,40 @@ void MergeDocument(std::filesystem::path path) {
 void LoadOriginals() {
   spdlog::info("Loading original input configs for merging");
 
-  inputContextsOriginal = LoadDocument("r6/config/inputContexts.xml");
+  bool contextsOk = true;
+  inputContextsOriginal =
+      LoadDocument("r6/config/inputContexts.xml", &contextsOk);
+  if (!contextsOk) {
+    // No bundled backup exists for inputContexts.xml (only inputUserMappings
+    // ships one). Log loudly so the user knows the merge will be incomplete.
+    spdlog::error("Failed to load r6/config/inputContexts.xml - merged "
+                  "output will be incomplete. Please verify the file exists "
+                  "and is valid XML.");
+  }
+
   // malformed XML in 1.6, so we need to load the supplied .xml if this fails
-  bool fixed = false;
+  bool mappingsOk = true;
   inputUserMappingsOriginal =
-      LoadDocument("r6/config/inputUserMappings.xml", &fixed);
-  if (!fixed) {
+      LoadDocument("r6/config/inputUserMappings.xml", &mappingsOk);
+  if (!mappingsOk) {
     spdlog::info("The above is a normal error in 1.6+ - loading backup "
                  "inputUserMappings.xml");
     inputUserMappingsOriginal =
         LoadDocument("red4ext/plugins/input_loader/inputUserMappings.xml");
   }
+}
+
+// Case-insensitive comparison for file extensions. NTFS preserves the stored
+// case, so a stray `.XML` mod file would otherwise be silently skipped by a
+// plain `== ".xml"` check.
+static bool HasXmlExtension(const std::filesystem::path &p) {
+  std::string ext = p.extension().string();
+  if (ext.size() != 4)
+    return false;
+  return (ext[0] == '.') &&
+         (ext[1] == 'x' || ext[1] == 'X') &&
+         (ext[2] == 'm' || ext[2] == 'M') &&
+         (ext[3] == 'l' || ext[3] == 'L');
 }
 
 bool LoadInputConfigs(RED4ext::CGameApplication *) {
@@ -166,52 +249,95 @@ bool LoadInputConfigs(RED4ext::CGameApplication *) {
     spdlog::info("Loading input configs from r6/input");
     for (const auto &entry :
          std::filesystem::recursive_directory_iterator(inputDir)) {
-      const auto &path = entry.path();
-      if (entry.path().extension() == ".xml") {
-        try {
-          MergeDocument(path);
-        } catch (const std::exception &ex) {
-          spdlog::error(L"An exception occured while trying to load '{}'",
-                        path.c_str());
-          // spdlog::error(ex.what());
-        } catch (...) {
-          spdlog::error(L"An unknown error occured while trying to load '{}'",
-                        path.c_str());
-        }
+      // Skip directories, symlinks, sockets, etc. Only merge regular files.
+      // This prevents following symlink loops and attempting to parse
+      // directory entries as XML.
+      std::error_code ec;
+      if (!entry.is_regular_file(ec)) {
+        continue;
       }
-    }
-    spdlog::info("Loading input configs from dynamically added paths");
-    for (const auto &path : document_paths) {
+      const auto &path = entry.path();
+      if (!HasXmlExtension(path)) {
+        continue;
+      }
       try {
         MergeDocument(path);
       } catch (const std::exception &ex) {
-        spdlog::error(L"An exception occured while trying to load '{}'",
+        spdlog::error(L"An exception occurred while trying to load '{}'",
                       path.c_str());
-        // spdlog::error(ex.what());
+        spdlog::error("Exception: {}", ex.what());
       } catch (...) {
-        spdlog::error(L"An unknown error occured while trying to load '{}'",
+        spdlog::error(L"An unknown error occurred while trying to load '{}'",
+                      path.c_str());
+      }
+    }
+
+    // Snapshot the dynamic paths under the mutex so we don't race with a
+    // late Add() call while iterating. (Late calls will simply be missed,
+    // matching previous behaviour, but at least we won't UB.)
+    std::vector<std::filesystem::path> dynamicPaths;
+    {
+      std::lock_guard<std::mutex> guard(document_paths_mutex);
+      dynamicPaths = document_paths;
+    }
+
+    spdlog::info("Loading input configs from dynamically added paths");
+    for (const auto &path : dynamicPaths) {
+      try {
+        MergeDocument(path);
+      } catch (const std::exception &ex) {
+        spdlog::error(L"An exception occurred while trying to load '{}'",
+                      path.c_str());
+        spdlog::error("Exception: {}", ex.what());
+      } catch (...) {
+        spdlog::error(L"An unknown error occurred while trying to load '{}'",
                       path.c_str());
       }
     }
   } catch (const std::exception &ex) {
-    spdlog::error(L"An exception occured while reading the directory '{}'",
+    spdlog::error(L"An exception occurred while reading the directory '{}'",
                   inputDir.c_str());
-    // spdlog::error(ex.what());
+    spdlog::error("Exception: {}", ex.what());
   } catch (...) {
-    spdlog::error(L"An unknown error occured while reading the directory '{}'",
+    spdlog::error(L"An unknown error occurred while reading the directory '{}'",
                   inputDir.c_str());
   }
 
+  // Ensure the cache directory exists - save_file() silently fails if it
+  // doesn't, which previously caused the game to start with an empty input
+  // configuration (broken controls).
+  auto cacheDir = Utils::GetRootDir() / "r6/cache";
+  try {
+    if (!std::filesystem::exists(cacheDir)) {
+      std::filesystem::create_directories(cacheDir);
+    }
+  } catch (const std::exception &ex) {
+    spdlog::error("Failed to create cache directory '{}': {}",
+                  cacheDir.string(), ex.what());
+  } catch (...) {
+    spdlog::error("Unknown error creating cache directory '{}'",
+                  cacheDir.string());
+  }
+
   // save files
-  inputContextsOriginal.save_file(
-      (Utils::GetRootDir() / "r6/cache/inputContexts.xml").string().c_str());
-  spdlog::info("Merged inputContexts saved to 'r6/cache/inputContexts.xml'");
-  inputUserMappingsOriginal.save_file(
-      (Utils::GetRootDir() / "r6/cache/inputUserMappings.xml")
-          .string()
-          .c_str());
-  spdlog::info(
-      "Merged inputUserMappings saved to 'r6/cache/inputUserMappings.xml'");
+  auto contextsCachePath = Utils::GetRootDir() / "r6/cache/inputContexts.xml";
+  if (!inputContextsOriginal.save_file(contextsCachePath.string().c_str())) {
+    spdlog::error("Failed to save merged inputContexts to '{}'",
+                  contextsCachePath.string());
+  } else {
+    spdlog::info("Merged inputContexts saved to 'r6/cache/inputContexts.xml'");
+  }
+
+  auto mappingsCachePath =
+      Utils::GetRootDir() / "r6/cache/inputUserMappings.xml";
+  if (!inputUserMappingsOriginal.save_file(
+          mappingsCachePath.string().c_str())) {
+    spdlog::error("Failed to save merged inputUserMappings to '{}'",
+                  mappingsCachePath.string());
+  } else {
+    spdlog::info(
+        "Merged inputUserMappings saved to 'r6/cache/inputUserMappings.xml'");
+  }
 
   return true;
 }
@@ -225,7 +351,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
     spdlog::info("Starting up Input Loader {}", MOD_VERSION_STR);
     break;
   }
-  return true;
+  return TRUE;
 }
 
 RED4EXT_C_EXPORT bool RED4EXT_CALL Main(RED4ext::PluginHandle aHandle,

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -136,6 +136,8 @@ void MergeDocument(std::filesystem::path path) {
   // * radialDeadzone
   // * angularDeadzone
 
+  // pugi::xml_document modDocument =
+  // LoadDocument("r6/input/flight_control.xml");
   bool loadOk = true;
   pugi::xml_document modDocument = LoadDocument(path, &loadOk);
   spdlog::info(L"Loading document: {}", path.c_str());

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -86,21 +86,55 @@ RED4EXT_C_EXPORT void Add(RED4ext::PluginHandle aHandle, const wchar_t * str) {
   if (path.is_relative()) {
     // Use the wide-character API to preserve Unicode paths and avoid the
     // 512-byte truncation bug the previous ANSI buffer suffered from.
-    // We dynamically resize, mirroring the approach in Utils::GetRootDir().
+    //
+    // GetModuleFileNameW does NOT clear the last error on success, so a stale
+    // ERROR_INSUFFICIENT_BUFFER from a previous iteration could persist and
+    // loop forever. Reset the last error before each call, and decide whether
+    // to grow using the return value (== bufferSize-1 means possible
+    // truncation) plus a fresh last-error check. Capture the error code
+    // immediately on failure so the log message is accurate.
     std::wstring dllFilePath;
     constexpr size_t pathChunk = MAX_PATH + 1;
-    do {
+    constexpr size_t kMaxResizeIterations = 16;
+    bool resolved = false;
+    DWORD lastErr = ERROR_SUCCESS;
+
+    for (size_t iter = 0; iter < kMaxResizeIterations; ++iter) {
       dllFilePath.resize(dllFilePath.size() + pathChunk, L'\0');
+
+      ::SetLastError(ERROR_SUCCESS);
       auto length = GetModuleFileNameW(aHandle, dllFilePath.data(),
                                        static_cast<uint32_t>(dllFilePath.size()));
-      if (length > 0) {
-        dllFilePath.resize(length);
-      }
-    } while (GetLastError() == ERROR_INSUFFICIENT_BUFFER);
 
-    if (dllFilePath.empty()) {
-      spdlog::error("InputLoader::Add() - GetModuleFileNameW failed (errno={:#x}); ignoring path '{}'",
-                    GetLastError(), path.string());
+      if (length == 0) {
+        lastErr = ::GetLastError();
+        spdlog::error("InputLoader::Add() - GetModuleFileNameW failed (errno={:#x}); ignoring path '{}'",
+                      lastErr, path.string());
+        return;
+      }
+
+      // GetModuleFileNameW returns chars written, NOT including NUL. If
+      // length < bufferSize-1, the path fit. If length == bufferSize-1, it
+      // *may* have been truncated - confirm with a fresh last-error check.
+      if (length < dllFilePath.size() - 1) {
+        dllFilePath.resize(length);
+        resolved = true;
+        break;
+      }
+
+      lastErr = ::GetLastError();
+      if (lastErr != ERROR_INSUFFICIENT_BUFFER) {
+        // Path is exactly bufferSize-1 chars - not truncation. Done.
+        dllFilePath.resize(length);
+        resolved = true;
+        break;
+      }
+      // else: confirmed truncation, loop and grow.
+    }
+
+    if (!resolved) {
+      spdlog::error("InputLoader::Add() - GetModuleFileNameW exhausted resize iterations (last errno={:#x}); ignoring path '{}'",
+                    lastErr, path.string());
       return;
     }
 
@@ -136,8 +170,6 @@ void MergeDocument(std::filesystem::path path) {
   // * radialDeadzone
   // * angularDeadzone
 
-  // pugi::xml_document modDocument =
-  // LoadDocument("r6/input/flight_control.xml");
   bool loadOk = true;
   pugi::xml_document modDocument = LoadDocument(path, &loadOk);
   spdlog::info(L"Loading document: {}", path.c_str());

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -11,6 +11,29 @@ void Utils::CreateLogger()
     auto logsDir = red4extDir / L"logs";
     spdlog::filename_t logFile = (logsDir / L"input_loader.log");
 
+    // Ensure the logs directory exists - basic_file_sink_mt will throw if it
+    // doesn't, and we're called from DllMain where a throw fails the DLL
+    // load entirely. RED4ext normally creates this, but be defensive.
+    try
+    {
+        if (!std::filesystem::exists(logsDir))
+        {
+            std::filesystem::create_directories(logsDir);
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        // Can't log yet - the logger isn't constructed. Output to the
+        // debugger as a last resort.
+        OutputDebugStringA("InputLoader: failed to create logs directory: ");
+        OutputDebugStringA(ex.what());
+        OutputDebugStringA("\n");
+    }
+    catch (...)
+    {
+        OutputDebugStringA("InputLoader: unknown error creating logs directory\n");
+    }
+
     auto console = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
     auto file = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFile, true);
 
@@ -41,6 +64,16 @@ std::filesystem::path Utils::GetRootDir()
         }
     } while (GetLastError() == ERROR_INSUFFICIENT_BUFFER);
 
+    if (filename.empty())
+    {
+        // GetModuleFileName failed before we ever got a usable path.
+        // Returning an empty path would lead to confusing errors downstream
+        // (every path operation would resolve relative to the CWD). Surface
+        // the failure so the user can act on it.
+        OutputDebugStringA("InputLoader: GetModuleFileName failed - returning empty root dir\n");
+        return std::filesystem::path();
+    }
+
     auto rootDir = std::filesystem::path(filename)
                        .parent_path()  // Resolve to "x64" directory.
                        .parent_path()  // Resolve to "bin" directory.
@@ -51,10 +84,30 @@ std::filesystem::path Utils::GetRootDir()
 
 std::wstring Utils::ToWString(const char* aText)
 {
+    if (!aText)
+    {
+        return std::wstring();
+    }
+
     auto length = strlen(aText);
+    if (length == 0)
+    {
+        return std::wstring();
+    }
 
     std::wstring result(L"", length);
-    mbstowcs(result.data(), aText, length);
+    // mbstowcs returns (size_t)-1 on invalid multi-byte sequences. Use
+    // MultiByteToWideChar which is more forgiving on Windows and lets us
+    // detect conversion failures explicitly.
+    int converted = MultiByteToWideChar(CP_ACP, 0, aText,
+                                        static_cast<int>(length),
+                                        result.data(),
+                                        static_cast<int>(length));
+    if (converted <= 0)
+    {
+        // Fallback: mbstowcs with the original buffer (best-effort).
+        mbstowcs(result.data(), aText, length);
+    }
 
     return result;
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -4,46 +4,67 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
+// Max number of path-resize iterations before we give up. Guard against
+// pathological loops where GetModuleFileName keeps returning truncation.
+constexpr size_t kMaxPathResizeIterations = 16;
+
 void Utils::CreateLogger()
 {
     auto rootDir = GetRootDir();
     auto red4extDir = rootDir / L"red4ext";
     auto logsDir = red4extDir / L"logs";
-    spdlog::filename_t logFile = (logsDir / L"input_loader.log");
+    auto logFilePath = logsDir / L"input_loader.log";
+    spdlog::filename_t logFile = logFilePath;  // implicit conversion to wstring on Windows
 
-    // Ensure the logs directory exists - basic_file_sink_mt will throw if it
-    // doesn't, and we're called from DllMain where a throw fails the DLL
-    // load entirely. RED4ext normally creates this, but be defensive.
+    // Set up a console-only logger first. This must NEVER throw - it is called
+    // from DllMain, where an uncaught exception fails the entire DLL load.
+    // If the file sink fails later, we still have a working logger.
+    auto console = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    auto logger = std::make_shared<spdlog::logger>("", spdlog::sinks_init_list{console});
+    spdlog::set_default_logger(logger);
+    logger->flush_on(spdlog::level::trace);
+    spdlog::set_level(spdlog::level::trace);
+
+    // Now try to add the file sink. The directory is created first because
+    // basic_file_sink_mt will throw if it doesn't exist; either way, wrap
+    // everything in try/catch so we keep the console-only logger on failure.
+    bool fileSinkOk = false;
     try
     {
         if (!std::filesystem::exists(logsDir))
         {
             std::filesystem::create_directories(logsDir);
         }
+        auto file = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFile, true);
+        logger->sinks().push_back(file);
+        fileSinkOk = true;
     }
     catch (const std::exception& ex)
     {
-        // Can't log yet - the logger isn't constructed. Output to the
-        // debugger as a last resort.
-        OutputDebugStringA("InputLoader: failed to create logs directory: ");
+        // Logger exists now, so we can use it - but the file sink failed.
+        // Also echo to the debugger in case spdlog itself is broken.
+        spdlog::error("InputLoader: failed to create log file sink at '{}': {}",
+                      logFilePath.string(), ex.what());
+        OutputDebugStringA("InputLoader: failed to create log file sink: ");
         OutputDebugStringA(ex.what());
         OutputDebugStringA("\n");
     }
     catch (...)
     {
-        OutputDebugStringA("InputLoader: unknown error creating logs directory\n");
+        spdlog::error("InputLoader: unknown error creating log file sink at '{}'",
+                      logFilePath.string());
+        OutputDebugStringA("InputLoader: unknown error creating log file sink\n");
     }
 
-    auto console = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    auto file = std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFile, true);
-
-    spdlog::sinks_init_list sinks = {console, file};
-
-    auto logger = std::make_shared<spdlog::logger>("", sinks);
-    spdlog::set_default_logger(logger);
-
-    logger->flush_on(spdlog::level::trace);
-    spdlog::set_level(spdlog::level::trace);
+    if (fileSinkOk)
+    {
+        spdlog::info("InputLoader logger initialized (console + file: {})",
+                     logFilePath.string());
+    }
+    else
+    {
+        spdlog::warn("InputLoader logger initialized (console only; file sink failed)");
+    }
 }
 
 std::filesystem::path Utils::GetRootDir()
@@ -51,26 +72,61 @@ std::filesystem::path Utils::GetRootDir()
     constexpr auto pathLength = MAX_PATH + 1;
 
     // Try to get the executable path until we can fit the length of the path.
+    //
+    // GetModuleFileName does NOT clear the last error on success, so a stale
+    // ERROR_INSUFFICIENT_BUFFER from a previous iteration could persist and
+    // make us loop forever even after a successful call. Reset the last error
+    // before each call and rely on the return value (== buffer size - 1 on
+    // truncation) plus a fresh last-error check to decide whether to grow.
     std::wstring filename;
-    do
+    for (size_t iter = 0; iter < kMaxPathResizeIterations; ++iter)
     {
-        filename.resize(filename.size() + pathLength, '\0');
+        filename.resize(filename.size() + pathLength, L'\0');
 
-        auto length = GetModuleFileName(nullptr, filename.data(), static_cast<uint32_t>(filename.size()));
-        if (length > 0)
+        ::SetLastError(ERROR_SUCCESS);
+        auto length = GetModuleFileName(nullptr, filename.data(),
+                                        static_cast<uint32_t>(filename.size()));
+
+        if (length == 0)
         {
-            // Resize it to the real, std::filesystem::path" will use the string's length instead of recounting it.
-            filename.resize(length);
+            // Genuine failure - capture the error code immediately so it
+            // isn't clobbered by subsequent calls.
+            const auto err = ::GetLastError();
+            OutputDebugStringA("InputLoader: GetModuleFileName failed (errno=");
+            char buf[32] = {0};
+            _ultoa(err, buf, 16);
+            OutputDebugStringA(buf);
+            OutputDebugStringA(") - returning empty root dir\n");
+            return std::filesystem::path();
         }
-    } while (GetLastError() == ERROR_INSUFFICIENT_BUFFER);
+
+        // GetModuleFileName returns the number of characters written, NOT
+        // including the NUL. If `length == bufferSize - 1`, the path may have
+        // been truncated; GetLastError() == ERROR_INSUFFICIENT_BUFFER confirms
+        // it. If length < bufferSize - 1, the path fit and we're done.
+        if (length < filename.size() - 1)
+        {
+            filename.resize(length);
+            break;
+        }
+
+        // Buffer was exactly full - could be truncation. Confirm via last
+        // error before growing.
+        const auto err = ::GetLastError();
+        if (err != ERROR_INSUFFICIENT_BUFFER)
+        {
+            // Not a truncation - the path happens to be exactly bufferSize-1
+            // chars. We're done.
+            filename.resize(length);
+            break;
+        }
+
+        // Truncation confirmed - loop and grow the buffer.
+    }
 
     if (filename.empty())
     {
-        // GetModuleFileName failed before we ever got a usable path.
-        // Returning an empty path would lead to confusing errors downstream
-        // (every path operation would resolve relative to the CWD). Surface
-        // the failure so the user can act on it.
-        OutputDebugStringA("InputLoader: GetModuleFileName failed - returning empty root dir\n");
+        OutputDebugStringA("InputLoader: GetModuleFileName exhausted resize iterations - returning empty root dir\n");
         return std::filesystem::path();
     }
 
@@ -95,19 +151,47 @@ std::wstring Utils::ToWString(const char* aText)
         return std::wstring();
     }
 
-    std::wstring result(L"", length);
-    // mbstowcs returns (size_t)-1 on invalid multi-byte sequences. Use
-    // MultiByteToWideChar which is more forgiving on Windows and lets us
-    // detect conversion failures explicitly.
-    int converted = MultiByteToWideChar(CP_ACP, 0, aText,
-                                        static_cast<int>(length),
-                                        result.data(),
-                                        static_cast<int>(length));
-    if (converted <= 0)
+    // Two-pass MultiByteToWideChar: first call asks for the required length,
+    // second call does the actual conversion. This avoids the UB of
+    // `std::wstring(L"", length)` (which copies `length` chars from a
+    // 1-character literal) and avoids leaving embedded NULs when fewer
+    // characters are produced than the input length.
+    const int inputLen = static_cast<int>(length);
+
+    int required = MultiByteToWideChar(CP_ACP, 0, aText, inputLen, nullptr, 0);
+    if (required <= 0)
     {
-        // Fallback: mbstowcs with the original buffer (best-effort).
-        mbstowcs(result.data(), aText, length);
+        // Conversion failed (e.g., invalid multi-byte sequence). Fall back to
+        // mbstowcs with a properly-sized buffer; mbstowcs stops at the input
+        // NUL terminator and writes at most `length` wide chars.
+        std::wstring fallback(length, L'\0');
+        mbstowcs(fallback.data(), aText, length);
+        // Trim at the first NUL in case mbstowcs produced fewer chars.
+        const auto nulPos = fallback.find(L'\0');
+        if (nulPos != std::wstring::npos)
+        {
+            fallback.resize(nulPos);
+        }
+        return fallback;
     }
 
+    std::wstring result(required, L'\0');
+    int converted = MultiByteToWideChar(CP_ACP, 0, aText, inputLen,
+                                        result.data(), required);
+    if (converted <= 0)
+    {
+        // Shouldn't happen since the sizing call succeeded, but be safe.
+        std::wstring fallback(length, L'\0');
+        mbstowcs(fallback.data(), aText, length);
+        const auto nulPos = fallback.find(L'\0');
+        if (nulPos != std::wstring::npos)
+        {
+            fallback.resize(nulPos);
+        }
+        return fallback;
+    }
+
+    // `converted` may be less than `required` in rare cases; resize to actual.
+    result.resize(converted);
     return result;
 }

--- a/src/stdafx.hpp
+++ b/src/stdafx.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <mutex>
+#include <string>
 #include <vector>
 
 #include <Windows.h>


### PR DESCRIPTION
Add defensive checks and better error handling across the codebase:

- FileStream: check IsOpen in Read/Seek/Flush, return failures early and use FlushFileBuffers.
- Main: add includes, move forward declaration, validate Add() args, use wide GetModuleFileNameW to preserve Unicode, guard document_paths with a mutex, snapshot paths before iterating, skip non-regular files, case-insensitive .xml check, handle malformed/missing <bindings>, report LoadDocument failures and save_file errors, ensure cache dir exists and return TRUE from DllMain.
- Utils: ensure logs directory exists (avoid throws in DllMain), handle GetModuleFileName failure, and use MultiByteToWideChar in ToWString with fallback.
- stdafx.hpp: add missing headers (algorithm, mutex, string).